### PR TITLE
Introducing communication with alchemist-server through socket connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,13 @@ STAT_COLOR=\033[2;33m
 
 all: test
 
-test:	test_server
+test:
 	${MAKE} test_helpers
 	${MAKE} test_api
 
-test_server:
-	@ echo "\n$(INFO_COLOR)Run server tests: $(NO_COLOR)\n"
-	$(ELIXIR) test/server_test.exs
-
 test_helpers:
 	@ echo "\n$(INFO_COLOR)Run helper tests: $(NO_COLOR)\n"
+	$(ELIXIR) test/helpers/process_commands_test.exs
 	$(ELIXIR) test/helpers/module_info_test.exs
 	$(ELIXIR) test/helpers/complete_test.exs
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,13 @@ STAT_COLOR=\033[2;33m
 all: test
 
 test:
+	${MAKE} test_servers
 	${MAKE} test_helpers
 	${MAKE} test_api
 
+test_servers:
+	@ echo "\n$(INFO_COLOR)Run server tests: $(NO_COLOR)\n"
+	$(ELIXIR) test/server/socket_test.exs
 test_helpers:
 	@ echo "\n$(INFO_COLOR)Run helper tests: $(NO_COLOR)\n"
 	$(ELIXIR) test/helpers/process_commands_test.exs

--- a/README.md
+++ b/README.md
@@ -49,10 +49,7 @@ responds by sending information back to the opened connection
 Example for a completion request:
 
 ```
-$ telnet localhost 55580
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
+$ nc localhost 55580
 COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
 ```
 $ cd elixir_project
 $ elixir path/to/alchemist-server/run.exs --env=dev --listen
-ok|locahost:55580
+ok|localhost:55580
 ```
 In this mode, when a client connects to the port, it
 responds by sending information back to the opened connection

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example for a completion request:
 COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
 ```
 
-## Read/Write commands through network socket
+## Read/Write through network socket
 ```
 $ cd elixir_project
 $ elixir path/to/alchemist-server/run.exs --env=dev --listen
@@ -49,7 +49,7 @@ responds by sending information back to the opened connection
 Example for a completion request:
 
 ```
-$ telnet localhost 55590
+$ telnet localhost 55580
 Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Elixir Mix project and serves with informations as the following:
 
 # Usage
 
-The server needs to be started inside an Elixir mix project like below:
+The server needs to be started inside an Elixir mix project, it can be started in two ways:
 
+## Read/Write through `STDIN/STDOUT`
 ```
 $ cd elixir_project
 $ elixir path/to/alchemist-server/run.exs --env=dev
 ```
-
-The Alchemist-Server API is `STDIN/STDOUT` based, when input sent to a
-running server process it responds by sending information back to the `STDOUT`.
+In this mode, when input sent to a running server process it
+responds by sending information back to the `STDOUT`.
 
 A request consisting of two parts, the request type and the request arguments.
 
@@ -34,6 +34,25 @@ Example for a completion request:
 ```
 [type]   [arguments]
 
+COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
+```
+
+## Read/Write commands through network socket
+```
+$ cd elixir_project
+$ elixir path/to/alchemist-server/run.exs --env=dev --listen
+ok|locahost:55580
+```
+In this mode, when a client connects to the port, it
+responds by sending information back to the opened connection
+
+Example for a completion request:
+
+```
+$ telnet localhost 55590
+Trying 127.0.0.1...
+Connected to localhost.
+Escape character is '^]'.
 COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The server needs to be started inside an Elixir mix project like below:
 
 ```
 $ cd elixir_project
-$ elixir path/to/alchemist-server/run.exs dev
+$ elixir path/to/alchemist-server/run.exs --env=dev
 ```
 
 The Alchemist-Server API is `STDIN/STDOUT` based, when input sent to a

--- a/lib/api/comp.exs
+++ b/lib/api/comp.exs
@@ -1,27 +1,29 @@
 Code.require_file "../helpers/complete.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Comp do
 
   @moduledoc false
 
   alias Alchemist.Helpers.Complete
+  alias Alchemist.Helpers.Response
 
-  def request(args, device) do
+  def request(args) do
     args
     |> normalize
-    |> process(device)
+    |> process
   end
 
-  def process([nil, _, imports, _], device) do
+  def process([nil, _, imports, _]) do
     Complete.run('', imports) ++ Complete.run('')
-    |> print(device)
+    |> response
   end
 
-  def process([hint, _context, imports, aliases], device) do
+  def process([hint, _context, imports, aliases]) do
     Application.put_env(:"alchemist.el", :aliases, aliases)
 
     Complete.run(hint, imports) ++ Complete.run(hint)
-    |> print(device)
+    |> response
   end
 
   defp normalize(request) do
@@ -31,11 +33,11 @@ defmodule Alchemist.API.Comp do
     [hint, context, imports, aliases]
   end
 
-  defp print(result, device) do
+  defp response(result) do
     result
     |> Enum.uniq
-    |> Enum.map(&IO.puts(device, &1))
-
-    IO.puts device, "END-OF-COMP"
+    |> Enum.join("\n")
+    |> Response.endmark("COMP")
   end
+
 end

--- a/lib/api/comp.exs
+++ b/lib/api/comp.exs
@@ -6,22 +6,22 @@ defmodule Alchemist.API.Comp do
 
   alias Alchemist.Helpers.Complete
 
-  def request(args, io_module) do
+  def request(args, device) do
     args
     |> normalize
-    |> process(io_module)
+    |> process(device)
   end
 
-  def process([nil, _, imports, _], io_module) do
+  def process([nil, _, imports, _], device) do
     Complete.run('', imports) ++ Complete.run('')
-    |> print(io_module)
+    |> print(device)
   end
 
-  def process([hint, _context, imports, aliases], io_module) do
+  def process([hint, _context, imports, aliases], device) do
     Application.put_env(:"alchemist.el", :aliases, aliases)
 
     Complete.run(hint, imports) ++ Complete.run(hint)
-    |> print(io_module)
+    |> print(device)
   end
 
   defp normalize(request) do
@@ -31,11 +31,11 @@ defmodule Alchemist.API.Comp do
     [hint, context, imports, aliases]
   end
 
-  defp print(result, io_module) do
+  defp print(result, device) do
     result
     |> Enum.uniq
-    |> Enum.map(&io_module.puts/1)
+    |> Enum.map(&IO.puts(device, &1))
 
-    io_module.puts "END-OF-COMP"
+    IO.puts device, "END-OF-COMP"
   end
 end

--- a/lib/api/comp.exs
+++ b/lib/api/comp.exs
@@ -6,22 +6,22 @@ defmodule Alchemist.API.Comp do
 
   alias Alchemist.Helpers.Complete
 
-  def request(args) do
+  def request(args, io_module) do
     args
     |> normalize
-    |> process
+    |> process(io_module)
   end
 
-  def process([nil, _, imports, _]) do
+  def process([nil, _, imports, _], io_module) do
     Complete.run('', imports) ++ Complete.run('')
-    |> print
+    |> print(io_module)
   end
 
-  def process([hint, _context, imports, aliases]) do
+  def process([hint, _context, imports, aliases], io_module) do
     Application.put_env(:"alchemist.el", :aliases, aliases)
 
     Complete.run(hint, imports) ++ Complete.run(hint)
-    |> print
+    |> print(io_module)
   end
 
   defp normalize(request) do
@@ -31,11 +31,11 @@ defmodule Alchemist.API.Comp do
     [hint, context, imports, aliases]
   end
 
-  defp print(result) do
+  defp print(result, io_module) do
     result
     |> Enum.uniq
-    |> Enum.map(&IO.puts/1)
+    |> Enum.map(&io_module.puts/1)
 
-    IO.puts "END-OF-COMP"
+    io_module.puts "END-OF-COMP"
   end
 end

--- a/lib/api/defl.exs
+++ b/lib/api/defl.exs
@@ -1,19 +1,28 @@
 Code.require_file "../helpers/module_info.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Defl do
 
   @moduledoc false
 
   alias Alchemist.Helpers.ModuleInfo
+  alias Alchemist.Helpers.Response
 
-  def request(args, device) do
-    defl = args
-            |> normalize
-            |> process
-
-    IO.puts device, defl
-    IO.puts device, "END-OF-DEFL"
+  def request(args) do
+    args
+    |> normalize
+    |> process
+    |> endmark("DEFL")
   end
+
+  defp endmark(nil , cmd) do
+    "\n" <> Response.endmark(nil, cmd)
+  end
+
+  defp endmark(response , cmd) do
+    Response.endmark(response, cmd)
+  end
+
 
   def process([nil, function, [context: _, imports: [], aliases: _]]) do
     look_for_kernel_functions(function)

--- a/lib/api/defl.exs
+++ b/lib/api/defl.exs
@@ -6,13 +6,13 @@ defmodule Alchemist.API.Defl do
 
   alias Alchemist.Helpers.ModuleInfo
 
-  def request(args) do
+  def request(args, io_module) do
     args
     |> normalize
     |> process
-    |> IO.puts
+    |> io_module.puts
 
-    IO.puts "END-OF-DEFL"
+    io_module.puts "END-OF-DEFL"
   end
 
   def process([nil, function, [context: _, imports: [], aliases: _]]) do

--- a/lib/api/defl.exs
+++ b/lib/api/defl.exs
@@ -6,13 +6,13 @@ defmodule Alchemist.API.Defl do
 
   alias Alchemist.Helpers.ModuleInfo
 
-  def request(args, io_module) do
-    args
-    |> normalize
-    |> process
-    |> io_module.puts
+  def request(args, device) do
+    defl = args
+            |> normalize
+            |> process
 
-    io_module.puts "END-OF-DEFL"
+    IO.puts device, defl
+    IO.puts device, "END-OF-DEFL"
   end
 
   def process([nil, function, [context: _, imports: [], aliases: _]]) do

--- a/lib/api/docl.exs
+++ b/lib/api/docl.exs
@@ -11,8 +11,6 @@ defmodule Alchemist.API.Docl do
   alias Alchemist.Helpers.CaptureIO
 
   def request(args, device) do
-    Application.put_env(:iex, :colors, [enabled: true])
-
     args
     |> normalize
     |> process(device)

--- a/lib/api/docl.exs
+++ b/lib/api/docl.exs
@@ -15,7 +15,7 @@ defmodule Alchemist.API.Docl do
     |> normalize
     |> process(device)
 
-    IO.puts device, "END, func_puts-OF-DOCL"
+    IO.puts device, "END-OF-DOCL"
   end
 
   def process([expr, modules, aliases], device) do

--- a/lib/api/docl.exs
+++ b/lib/api/docl.exs
@@ -8,14 +8,14 @@ defmodule Alchemist.API.Docl do
 
   alias Alchemist.Helpers.ModuleInfo
 
-  def request(args) do
+  def request(args, io_module) do
     Application.put_env(:iex, :colors, [enabled: true])
 
     args
     |> normalize
     |> process
 
-    IO.puts "END-OF-DOCL"
+    io_module.puts "END, func_puts-OF-DOCL"
   end
 
   def process([expr, modules, aliases]) do

--- a/lib/api/docl.exs
+++ b/lib/api/docl.exs
@@ -8,14 +8,14 @@ defmodule Alchemist.API.Docl do
 
   alias Alchemist.Helpers.ModuleInfo
 
-  def request(args, io_module) do
+  def request(args, device) do
     Application.put_env(:iex, :colors, [enabled: true])
 
     args
     |> normalize
     |> process
 
-    io_module.puts "END, func_puts-OF-DOCL"
+    IO.puts device, "END, func_puts-OF-DOCL"
   end
 
   def process([expr, modules, aliases]) do

--- a/lib/api/eval.exs
+++ b/lib/api/eval.exs
@@ -1,61 +1,71 @@
+Code.require_file "../helpers/response.exs", __DIR__
+
 defmodule Alchemist.API.Eval do
 
   @moduledoc false
 
-  def request(args, device) do
+  alias Alchemist.Helpers.CaptureIO
+  alias Alchemist.Helpers.Response
+
+  def request(args) do
     args
     |> normalize
-    |> process(device)
-
-    IO.puts device, "END-OF-EVAL"
+    |> process
+    |> Response.endmark("EVAL")
   end
 
-  def process({:eval, file}, device) do
-    try do
-      eval = File.read!("#{file}")
-              |> Code.eval_string
-              |> Tuple.to_list
-              |> List.first
-
-      IO.inspect device, eval, []
-    rescue
-      e -> IO.inspect device, e, []
-    end
+  def process({:eval, file}) do
+    CaptureIO.capture_io(fn ->
+      try do
+        File.read!("#{file}")
+        |> Code.eval_string
+        |> Tuple.to_list
+        |> List.first
+        |> IO.inspect
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
-  def process({:quote, file}, device) do
-    try do
-      quot = File.read!("#{file}")
-      |> Code.string_to_quoted
-      |> Tuple.to_list
-      |> List.last
-
-      IO.inspect device, quot, []
-    rescue
-      e -> IO.inspect device, e, []
-    end
+  def process({:quote, file}) do
+    CaptureIO.capture_io(fn ->
+      try do
+        File.read!("#{file}")
+        |> Code.string_to_quoted
+        |> Tuple.to_list
+        |> List.last
+        |> IO.inspect
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
-  def process({:expand, file}, device) do
-    try do
-      {_, expr} = File.read!("#{file}")
-      |> Code.string_to_quoted
-      res = Macro.expand(expr, __ENV__)
-      IO.puts device, Macro.to_string(res)
-    rescue
-      e -> IO.inspect device, e, []
-    end
+  def process({:expand, file}) do
+    CaptureIO.capture_io(fn ->
+      try do
+        {_, expr} = File.read!("#{file}")
+                    |> Code.string_to_quoted
+        res = Macro.expand(expr, __ENV__)
+        IO.puts Macro.to_string(res)
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
-  def process({:expand_once, file}, device) do
-    try do
-      {_, expr} = File.read!("#{file}")
-      |> Code.string_to_quoted
-      res = Macro.expand_once(expr, __ENV__)
-      IO.puts device, Macro.to_string(res)
-    rescue
-      e -> IO.inspect e
-    end
+  def process({:expand_once, file}) do
+    CaptureIO.capture_io(fn ->
+      try do
+        {_, expr} = File.read!("#{file}")
+                    |> Code.string_to_quoted
+        res = Macro.expand_once(expr, __ENV__)
+        IO.puts Macro.to_string(res)
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
   def normalize(request) do

--- a/lib/api/eval.exs
+++ b/lib/api/eval.exs
@@ -2,55 +2,55 @@ defmodule Alchemist.API.Eval do
 
   @moduledoc false
 
-  def request(args) do
+  def request(args, io_module) do
     args
     |> normalize
-    |> process
+    |> process(io_module)
 
-    IO.puts "END-OF-EVAL"
+    io_module.puts "END-OF-EVAL"
   end
 
-  def process({:eval, file}) do
+  def process({:eval, file}, io_module) do
     try do
       File.read!("#{file}")
       |> Code.eval_string
       |> Tuple.to_list
       |> List.first
-      |> IO.inspect
+      |> io_module.inspect
     rescue
-      e -> IO.inspect e
+      e -> io_module.inspect e
     end
   end
 
-  def process({:quote, file}) do
+  def process({:quote, file}, io_module) do
     try do
       File.read!("#{file}")
       |> Code.string_to_quoted
       |> Tuple.to_list
       |> List.last
-      |> IO.inspect
+      |> io_module.inspect
     rescue
-      e -> IO.inspect e
+      e -> io_module.inspect e
     end
   end
 
-  def process({:expand, file}) do
+  def process({:expand, file}, io_module) do
     try do
       {_, expr} = File.read!("#{file}")
       |> Code.string_to_quoted
       res = Macro.expand(expr, __ENV__)
-      IO.puts Macro.to_string(res)
+      io_module.puts Macro.to_string(res)
     rescue
-      e -> IO.inspect e
+      e -> io_module.inspect e
     end
   end
 
-  def process({:expand_once, file}) do
+  def process({:expand_once, file}, io_module) do
     try do
       {_, expr} = File.read!("#{file}")
       |> Code.string_to_quoted
       res = Macro.expand_once(expr, __ENV__)
-      IO.puts Macro.to_string(res)
+      io_module.puts Macro.to_string(res)
     rescue
       e -> IO.inspect e
     end

--- a/lib/api/eval.exs
+++ b/lib/api/eval.exs
@@ -2,55 +2,57 @@ defmodule Alchemist.API.Eval do
 
   @moduledoc false
 
-  def request(args, io_module) do
+  def request(args, device) do
     args
     |> normalize
-    |> process(io_module)
+    |> process(device)
 
-    io_module.puts "END-OF-EVAL"
+    IO.puts device, "END-OF-EVAL"
   end
 
-  def process({:eval, file}, io_module) do
+  def process({:eval, file}, device) do
     try do
-      File.read!("#{file}")
-      |> Code.eval_string
-      |> Tuple.to_list
-      |> List.first
-      |> io_module.inspect
+      eval = File.read!("#{file}")
+              |> Code.eval_string
+              |> Tuple.to_list
+              |> List.first
+
+      IO.inspect device, eval, []
     rescue
-      e -> io_module.inspect e
+      e -> IO.inspect device, e, []
     end
   end
 
-  def process({:quote, file}, io_module) do
+  def process({:quote, file}, device) do
     try do
-      File.read!("#{file}")
+      quot = File.read!("#{file}")
       |> Code.string_to_quoted
       |> Tuple.to_list
       |> List.last
-      |> io_module.inspect
+
+      IO.inspect device, quot, []
     rescue
-      e -> io_module.inspect e
+      e -> IO.inspect device, e, []
     end
   end
 
-  def process({:expand, file}, io_module) do
+  def process({:expand, file}, device) do
     try do
       {_, expr} = File.read!("#{file}")
       |> Code.string_to_quoted
       res = Macro.expand(expr, __ENV__)
-      io_module.puts Macro.to_string(res)
+      IO.puts device, Macro.to_string(res)
     rescue
-      e -> io_module.inspect e
+      e -> IO.inspect device, e, []
     end
   end
 
-  def process({:expand_once, file}, io_module) do
+  def process({:expand_once, file}, device) do
     try do
       {_, expr} = File.read!("#{file}")
       |> Code.string_to_quoted
       res = Macro.expand_once(expr, __ENV__)
-      io_module.puts Macro.to_string(res)
+      IO.puts device, Macro.to_string(res)
     rescue
       e -> IO.inspect e
     end

--- a/lib/api/info.exs
+++ b/lib/api/info.exs
@@ -10,13 +10,13 @@ defmodule Alchemist.API.Info do
   alias Alchemist.Helpers.ModuleInfo
   alias Alchemist.Helpers.Complete
 
-  def request(args, io_module) do
+  def request(args, device) do
     args
     |> normalize
-    |> process(io_module)
+    |> process(device)
   end
 
-  def process(:modules, io_module) do
+  def process(:modules, device) do
     modules = ModuleInfo.all_applications_modules
     |> Enum.uniq
     |> Enum.reject(&is_nil/1)
@@ -26,12 +26,12 @@ defmodule Alchemist.API.Info do
 
     modules ++ functions
     |> Enum.uniq
-    |> Enum.map(&io_module.puts/1)
+    |> Enum.map(&IO.puts(device, &1))
 
-    io_module.puts "END-OF-INFO"
+    IO.puts device, "END-OF-INFO"
   end
 
-  def process(:mixtasks, io_module) do
+  def process(:mixtasks, device) do
     # append things like hex or phoenix archives to the load_path
     Mix.Local.append_archives
 
@@ -39,33 +39,33 @@ defmodule Alchemist.API.Info do
     |> Mix.Task.load_tasks
     |> Enum.map(&Mix.Task.task_name/1)
     |> Enum.sort
-    |> Enum.map(&io_module.puts/1)
+    |> Enum.map(&IO.puts(device, &1))
 
-    io_module.puts "END-OF-INFO"
+    IO.puts device, "END-OF-INFO"
   end
 
-  def process({:info, arg}, io_module) do
+  def process({:info, arg}, device) do
     try do
       Code.eval_string("i(#{arg})", [], __ENV__)
     rescue
       _e -> nil
     end
 
-    io_module.puts "END-OF-INFO"
+    IO.puts device, "END-OF-INFO"
   end
 
-  def process({:types, arg}, io_module) do
+  def process({:types, arg}, device) do
     try do
       Code.eval_string("t(#{arg})", [], __ENV__)
     rescue
       _e -> nil
     end
 
-    io_module.puts "END-OF-INFO"
+    IO.puts device, "END-OF-INFO"
   end
 
-  def process(nil, io_module) do
-   io_module.puts "END-OF-INFO"
+  def process(nil, device) do
+   IO.puts device, "END-OF-INFO"
   end
 
   def normalize(request) do

--- a/lib/api/info.exs
+++ b/lib/api/info.exs
@@ -1,5 +1,6 @@
 Code.require_file "../helpers/module_info.exs", __DIR__
 Code.require_file "../helpers/complete.exs", __DIR__
+Code.require_file "../helpers/capture_io.exs", __DIR__
 
 defmodule Alchemist.API.Info do
 
@@ -9,6 +10,7 @@ defmodule Alchemist.API.Info do
 
   alias Alchemist.Helpers.ModuleInfo
   alias Alchemist.Helpers.Complete
+  alias Alchemist.Helpers.CaptureIO
 
   def request(args, device) do
     args
@@ -46,7 +48,10 @@ defmodule Alchemist.API.Info do
 
   def process({:info, arg}, device) do
     try do
-      Code.eval_string("i(#{arg})", [], __ENV__)
+      info = CaptureIO.capture_io(fn ->
+        Code.eval_string("i(#{arg})", [], __ENV__)
+      end)
+      IO.write device, info
     rescue
       _e -> nil
     end
@@ -56,7 +61,11 @@ defmodule Alchemist.API.Info do
 
   def process({:types, arg}, device) do
     try do
-      Code.eval_string("t(#{arg})", [], __ENV__)
+      type = CaptureIO.capture_io(fn ->
+        Code.eval_string("t(#{arg})", [], __ENV__)
+      end)
+
+      IO.write device, type
     rescue
       _e -> nil
     end

--- a/lib/api/info.exs
+++ b/lib/api/info.exs
@@ -10,13 +10,13 @@ defmodule Alchemist.API.Info do
   alias Alchemist.Helpers.ModuleInfo
   alias Alchemist.Helpers.Complete
 
-  def request(args) do
+  def request(args, io_module) do
     args
     |> normalize
-    |> process
+    |> process(io_module)
   end
 
-  def process(:modules) do
+  def process(:modules, io_module) do
     modules = ModuleInfo.all_applications_modules
     |> Enum.uniq
     |> Enum.reject(&is_nil/1)
@@ -26,12 +26,12 @@ defmodule Alchemist.API.Info do
 
     modules ++ functions
     |> Enum.uniq
-    |> Enum.map(&IO.puts/1)
+    |> Enum.map(&io_module.puts/1)
 
-    IO.puts "END-OF-INFO"
+    io_module.puts "END-OF-INFO"
   end
 
-  def process(:mixtasks) do
+  def process(:mixtasks, io_module) do
     # append things like hex or phoenix archives to the load_path
     Mix.Local.append_archives
 
@@ -39,33 +39,33 @@ defmodule Alchemist.API.Info do
     |> Mix.Task.load_tasks
     |> Enum.map(&Mix.Task.task_name/1)
     |> Enum.sort
-    |> Enum.map(&IO.puts/1)
+    |> Enum.map(&io_module.puts/1)
 
-    IO.puts "END-OF-INFO"
+    io_module.puts "END-OF-INFO"
   end
 
-  def process({:info, arg}) do
+  def process({:info, arg}, io_module) do
     try do
       Code.eval_string("i(#{arg})", [], __ENV__)
     rescue
       _e -> nil
     end
 
-    IO.puts "END-OF-INFO"
+    io_module.puts "END-OF-INFO"
   end
 
-  def process({:types, arg}) do
+  def process({:types, arg}, io_module) do
     try do
       Code.eval_string("t(#{arg})", [], __ENV__)
     rescue
       _e -> nil
     end
 
-    IO.puts "END-OF-INFO"
+    io_module.puts "END-OF-INFO"
   end
 
-  def process(nil) do
-    IO.puts "END-OF-INFO"
+  def process(nil, io_module) do
+   io_module.puts "END-OF-INFO"
   end
 
   def normalize(request) do

--- a/lib/api/ping.exs
+++ b/lib/api/ping.exs
@@ -1,13 +1,12 @@
+Code.require_file "../helpers/response.exs", __DIR__
+
 defmodule Alchemist.API.Ping do
 
   @moduledoc false
 
-  def request(device) do
-    process(device)
-  end
+  alias Alchemist.Helpers.Response
 
-  def process(device) do
-    IO.puts device, "PONG"
-    IO.puts device, "END-OF-PING"
+  def request do
+    Response.endmark("PONG", "PING")
   end
 end

--- a/lib/api/ping.exs
+++ b/lib/api/ping.exs
@@ -2,12 +2,12 @@ defmodule Alchemist.API.Ping do
 
   @moduledoc false
 
-  def request(io_module) do
-    process(io_module)
+  def request(device) do
+    process(device)
   end
 
-  def process(io_module) do
-    io_module.puts "PONG"
-    io_module.puts "END-OF-PING"
+  def process(device) do
+    IO.puts device, "PONG"
+    IO.puts device, "END-OF-PING"
   end
 end

--- a/lib/api/ping.exs
+++ b/lib/api/ping.exs
@@ -2,12 +2,12 @@ defmodule Alchemist.API.Ping do
 
   @moduledoc false
 
-  def request do
-    process
+  def request(io_module) do
+    process(io_module)
   end
 
-  def process do
-    IO.puts "PONG"
-    IO.puts "END-OF-PING"
+  def process(io_module) do
+    io_module.puts "PONG"
+    io_module.puts "END-OF-PING"
   end
 end

--- a/lib/helpers/capture_io.exs
+++ b/lib/helpers/capture_io.exs
@@ -1,0 +1,38 @@
+defmodule Alchemist.Helpers.CaptureIO do
+
+  @docmodule false
+
+  def capture_io(fun) do
+    do_capture_io(:standard_io, [], fun)
+  end
+
+  defp do_capture_io(:standard_io, options, fun) do
+    prompt_config = Keyword.get(options, :capture_prompt, true)
+    input = Keyword.get(options, :input, "")
+
+    original_gl = Process.group_leader()
+    {:ok, capture_gl} = StringIO.open(input, capture_prompt: prompt_config)
+    try do
+      Process.group_leader(self(), capture_gl)
+      do_capture_io(capture_gl, fun)
+    after
+      Process.group_leader(self(), original_gl)
+    end
+  end
+
+  def do_capture_io(string_io, fun) do
+    try do
+       _ = fun.()
+      :ok
+    catch
+      kind, reason ->
+        stack = System.stacktrace()
+        _ = StringIO.close(string_io)
+        :erlang.raise(kind, reason, stack)
+    else
+      :ok ->
+        {:ok, output} = StringIO.close(string_io)
+        elem(output, 1)
+    end
+  end
+end

--- a/lib/helpers/process_commands.exs
+++ b/lib/helpers/process_commands.exs
@@ -1,0 +1,79 @@
+Code.require_file "../api/comp.exs", __DIR__
+Code.require_file "../api/docl.exs", __DIR__
+Code.require_file "../api/defl.exs", __DIR__
+Code.require_file "../api/eval.exs", __DIR__
+Code.require_file "../api/info.exs", __DIR__
+Code.require_file "../api/ping.exs", __DIR__
+
+defmodule Alchemist.Helpers.ProcessCommands do
+
+  @moduledoc false
+
+  alias Alchemist.API
+
+  def process(line, env, device) do
+    loaded = all_loaded
+
+    paths = load_paths(env)
+    apps  = load_apps(env)
+
+    read_input(line, device)
+    purge_modules(loaded)
+    purge_paths(paths)
+    purge_apps(apps)
+  end
+
+  defp read_input(line, device) do
+    case line |> String.split(" ", parts: 2) do
+      ["COMP", args] ->
+        API.Comp.request(args, device)
+      ["DOCL", args] ->
+        API.Docl.request(args, device)
+      ["INFO", args] ->
+        API.Info.request(args, device)
+      ["EVAL", args] ->
+        API.Eval.request(args, device)
+      ["DEFL", args] ->
+        API.Defl.request(args, device)
+      ["PING"] ->
+        API.Ping.request(device)
+      _ ->
+        nil
+    end
+  end
+
+  defp all_loaded() do
+    for {m,_} <- :code.all_loaded, do: m
+  end
+
+  defp load_paths(env) do
+    for path <- Path.wildcard("_build/#{env}/lib/*/ebin") do
+      Code.prepend_path(path)
+      path
+    end
+  end
+
+  defp load_apps(env) do
+    for path <- Path.wildcard("_build/#{env}/lib/*/ebin/*.app") do
+      app = path |> Path.basename() |> Path.rootname() |> String.to_atom
+      Application.load(app)
+      app
+    end
+  end
+
+  defp purge_modules(loaded) do
+    for m <- (all_loaded() -- loaded) do
+      :code.delete(m)
+      :code.purge(m)
+    end
+  end
+
+  defp purge_paths(paths) do
+    for p <- paths, do: Code.delete_path(p)
+  end
+
+  defp purge_apps(apps) do
+    for a <- apps, do: Application.unload(a)
+  end
+
+end

--- a/lib/helpers/process_commands.exs
+++ b/lib/helpers/process_commands.exs
@@ -11,32 +11,33 @@ defmodule Alchemist.Helpers.ProcessCommands do
 
   alias Alchemist.API
 
-  def process(line, env, device) do
+  def process(line, env) do
     loaded = all_loaded
 
     paths = load_paths(env)
     apps  = load_apps(env)
 
-    read_input(line, device)
+    result = execute_input(line)
     purge_modules(loaded)
     purge_paths(paths)
     purge_apps(apps)
+    result
   end
 
-  defp read_input(line, device) do
+  defp execute_input(line) do
     case line |> String.split(" ", parts: 2) do
       ["COMP", args] ->
-        API.Comp.request(args, device)
+        API.Comp.request(args)
       ["DOCL", args] ->
-        API.Docl.request(args, device)
+        API.Docl.request(args)
       ["INFO", args] ->
-        API.Info.request(args, device)
+        API.Info.request(args)
       ["EVAL", args] ->
-        API.Eval.request(args, device)
+        API.Eval.request(args)
       ["DEFL", args] ->
-        API.Defl.request(args, device)
+        API.Defl.request(args)
       ["PING"] ->
-        API.Ping.request(device)
+        API.Ping.request()
       _ ->
         nil
     end

--- a/lib/helpers/response.exs
+++ b/lib/helpers/response.exs
@@ -1,0 +1,17 @@
+defmodule Alchemist.Helpers.Response do
+
+  @moduledoc false
+
+  def endmark(nil, cmd) do
+    "END-OF-#{cmd}\n"
+  end
+
+  def endmark("", cmd) do
+    "END-OF-#{cmd}\n"
+  end
+
+  def endmark(response, cmd) do
+    response = String.strip(response)
+    "#{response}\nEND-OF-#{cmd}\n"
+  end
+end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -23,6 +23,8 @@ defmodule Alchemist.Server do
   def start([args]) do
     {opts, _, _} = OptionParser.parse(args)
     env = Keyword.get(opts, :env, "dev")
+    noansi = Keyword.get(opts, :no_ansi, false)
+    Application.put_env(:iex, :colors, [enabled: !noansi])
     case Keyword.get(opts, :listen, false) do
       false -> ServerIO.start([env: env])
       true -> ServerSocket.start([env: env])

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -3,6 +3,7 @@ Code.require_file "api/docl.exs", __DIR__
 Code.require_file "api/defl.exs", __DIR__
 Code.require_file "api/eval.exs", __DIR__
 Code.require_file "api/info.exs", __DIR__
+Code.require_file "server/io.exs", __DIR__
 
 defmodule Alchemist.Server do
 
@@ -21,17 +22,18 @@ defmodule Alchemist.Server do
   """
 
   alias Alchemist.API
+  alias Alchemist.Server.IO, as: ServerIO
 
   def start([env]) do
     loop(all_loaded(), env)
   end
 
   def loop(loaded, env) do
-    line  = IO.gets("") |> String.rstrip()
+    line  = ServerIO.gets
     paths = load_paths(env)
     apps  = load_apps(env)
 
-    read_input(line)
+    read_input(line, ServerIO)
 
     purge_modules(loaded)
     purge_paths(paths)
@@ -40,18 +42,18 @@ defmodule Alchemist.Server do
     loop(loaded, env)
   end
 
-  def read_input(line) do
+  def read_input(line, io_module) do
     case line |> String.split(" ", parts: 2) do
       ["COMP", args] ->
-        API.Comp.request(args)
+        API.Comp.request(args, io_module)
       ["DOCL", args] ->
-        API.Docl.request(args)
+        API.Docl.request(args, io_module)
       ["INFO", args] ->
-        API.Info.request(args)
+        API.Info.request(args, io_module)
       ["EVAL", args] ->
-        API.Eval.request(args)
+        API.Eval.request(args, io_module)
       ["DEFL", args] ->
-        API.Defl.request(args)
+        API.Defl.request(args, io_module)
       _ ->
         nil
     end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -34,7 +34,7 @@ defmodule Alchemist.Server do
     paths = load_paths(env)
     apps  = load_apps(env)
 
-    read_input(line, ServerIO)
+    read_input(line, Process.group_leader)
 
     purge_modules(loaded)
     purge_paths(paths)
@@ -43,20 +43,20 @@ defmodule Alchemist.Server do
     loop(loaded, env)
   end
 
-  def read_input(line, io_module) do
+  def read_input(line, device) do
     case line |> String.split(" ", parts: 2) do
       ["COMP", args] ->
-        API.Comp.request(args, io_module)
+        API.Comp.request(args, device)
       ["DOCL", args] ->
-        API.Docl.request(args, io_module)
+        API.Docl.request(args, device)
       ["INFO", args] ->
-        API.Info.request(args, io_module)
+        API.Info.request(args, device)
       ["EVAL", args] ->
-        API.Eval.request(args, io_module)
+        API.Eval.request(args, device)
       ["DEFL", args] ->
-        API.Defl.request(args, io_module)
+        API.Defl.request(args, device)
       ["PING"] ->
-        API.Ping.request(io_module)
+        API.Ping.request(device)
       _ ->
         nil
     end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -1,9 +1,3 @@
-Code.require_file "api/comp.exs", __DIR__
-Code.require_file "api/docl.exs", __DIR__
-Code.require_file "api/defl.exs", __DIR__
-Code.require_file "api/eval.exs", __DIR__
-Code.require_file "api/info.exs", __DIR__
-Code.require_file "api/ping.exs", __DIR__
 Code.require_file "server/io.exs", __DIR__
 
 defmodule Alchemist.Server do
@@ -22,77 +16,12 @@ defmodule Alchemist.Server do
     * Listing of all available Modules with documentation.
   """
 
-  alias Alchemist.API
   alias Alchemist.Server.IO, as: ServerIO
 
-  def start([env]) do
-    loop(all_loaded(), env)
-  end
-
-  def loop(loaded, env) do
-    line  = ServerIO.gets
-    paths = load_paths(env)
-    apps  = load_apps(env)
-
-    read_input(line, Process.group_leader)
-
-    purge_modules(loaded)
-    purge_paths(paths)
-    purge_apps(apps)
-
-    loop(loaded, env)
-  end
-
-  def read_input(line, device) do
-    case line |> String.split(" ", parts: 2) do
-      ["COMP", args] ->
-        API.Comp.request(args, device)
-      ["DOCL", args] ->
-        API.Docl.request(args, device)
-      ["INFO", args] ->
-        API.Info.request(args, device)
-      ["EVAL", args] ->
-        API.Eval.request(args, device)
-      ["DEFL", args] ->
-        API.Defl.request(args, device)
-      ["PING"] ->
-        API.Ping.request(device)
-      _ ->
-        nil
-    end
-  end
-
-  defp all_loaded() do
-    for {m,_} <- :code.all_loaded, do: m
-  end
-
-  defp load_paths(env) do
-    for path <- Path.wildcard("_build/#{env}/lib/*/ebin") do
-      Code.prepend_path(path)
-      path
-    end
-  end
-
-  defp load_apps(env) do
-    for path <- Path.wildcard("_build/#{env}/lib/*/ebin/*.app") do
-      app = path |> Path.basename() |> Path.rootname() |> String.to_atom
-      Application.load(app)
-      app
-    end
-  end
-
-  defp purge_modules(loaded) do
-    for m <- (all_loaded() -- loaded) do
-      :code.delete(m)
-      :code.purge(m)
-    end
-  end
-
-  defp purge_paths(paths) do
-    for p <- paths, do: Code.delete_path(p)
-  end
-
-  defp purge_apps(apps) do
-    for a <- apps, do: Application.unload(a)
+  def start([args]) do
+    {opts, _, _} = OptionParser.parse(args)
+    env = Keyword.get(opts, :env, "dev")
+    ServerIO.start(env)
+    :timer.sleep :infinity
   end
 end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -1,4 +1,5 @@
 Code.require_file "server/io.exs", __DIR__
+Code.require_file "server/socket.exs", __DIR__
 
 defmodule Alchemist.Server do
 
@@ -17,11 +18,15 @@ defmodule Alchemist.Server do
   """
 
   alias Alchemist.Server.IO, as: ServerIO
+  alias Alchemist.Server.Socket, as: ServerSocket
 
   def start([args]) do
     {opts, _, _} = OptionParser.parse(args)
     env = Keyword.get(opts, :env, "dev")
-    ServerIO.start(env)
+    case Keyword.get(opts, :listen, false) do
+      false -> ServerIO.start(env)
+      true -> ServerSocket.start(nil, [env: env])
+    end
     :timer.sleep :infinity
   end
 end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -56,7 +56,7 @@ defmodule Alchemist.Server do
       ["DEFL", args] ->
         API.Defl.request(args, io_module)
       ["PING"] ->
-        API.Ping.request()
+        API.Ping.request(io_module)
       _ ->
         nil
     end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -24,8 +24,8 @@ defmodule Alchemist.Server do
     {opts, _, _} = OptionParser.parse(args)
     env = Keyword.get(opts, :env, "dev")
     case Keyword.get(opts, :listen, false) do
-      false -> ServerIO.start(env)
-      true -> ServerSocket.start(nil, [env: env])
+      false -> ServerIO.start([env: env])
+      true -> ServerSocket.start([env: env])
     end
     :timer.sleep :infinity
   end

--- a/lib/server/io.exs
+++ b/lib/server/io.exs
@@ -18,7 +18,8 @@ defmodule Alchemist.Server.IO do
   end
 
   def handle_info(:timeout, env) do
-    ProcessCommands.process(read_line, env, Process.group_leader)
+    ProcessCommands.process(read_line, env)
+    |> IO.write
     {:noreply, env, 0}
   end
 

--- a/lib/server/io.exs
+++ b/lib/server/io.exs
@@ -1,0 +1,16 @@
+defmodule Alchemist.Server.IO do
+
+  @moduledoc false
+
+  def gets do
+    IO.gets("") |> String.rstrip()
+  end
+
+  def puts(line) do
+    IO.puts line
+  end
+
+  def inspect(item) do
+    IO.inspect item
+  end
+end

--- a/lib/server/io.exs
+++ b/lib/server/io.exs
@@ -8,7 +8,8 @@ defmodule Alchemist.Server.IO do
 
   alias Alchemist.Helpers.ProcessCommands
 
-  def start(env) do
+  def start(opts) do
+    env = Keyword.get(opts, :env)
     GenServer.start_link(__MODULE__,  env, [])
   end
 

--- a/lib/server/io.exs
+++ b/lib/server/io.exs
@@ -1,16 +1,27 @@
+Code.require_file "../helpers/process_commands.exs", __DIR__
+
 defmodule Alchemist.Server.IO do
 
   @moduledoc false
 
-  def gets do
+  use GenServer
+
+  alias Alchemist.Helpers.ProcessCommands
+
+  def start(env) do
+    GenServer.start_link(__MODULE__,  env, [])
+  end
+
+  def init(env) do
+    {:ok, env, 0}
+  end
+
+  def handle_info(:timeout, env) do
+    ProcessCommands.process(read_line, env, Process.group_leader)
+    {:noreply, env, 0}
+  end
+
+  def read_line do
     IO.gets("") |> String.rstrip()
-  end
-
-  def puts(line) do
-    IO.puts line
-  end
-
-  def inspect(item) do
-    IO.inspect item
   end
 end

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -24,7 +24,7 @@ defmodule Alchemist.Server.Socket do
     {:ok, socket} = :gen_tcp.listen(port,
                     [:binary, packet: :line, active: false, reuseaddr: true])
     {:ok, port} = :inet.port(socket)
-    IO.puts "ok|locahost:#{port}"
+    IO.puts "ok|localhost:#{port}"
     loop_acceptor(socket, env)
   end
 

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -1,0 +1,60 @@
+Code.require_file "../helpers/process_commands.exs", __DIR__
+
+defmodule Alchemist.Server.Socket do
+  use Application
+
+  alias Alchemist.Helpers.ProcessCommands
+
+  def start(_type, opts) do
+    import Supervisor.Spec
+
+    env = Keyword.get(opts, :env)
+    port = Keyword.get(opts, :port, 0)
+
+    children = [
+      supervisor(Task.Supervisor, [[name: Alchemist.Server.Socket.TaskSupervisor]]),
+      worker(Task, [__MODULE__, :accept, [env, port]])
+    ]
+
+    opts = [strategy: :one_for_one, name: KVServer.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def accept(env, port) do
+    {:ok, socket} = :gen_tcp.listen(port,
+                    [:binary, packet: :line, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(socket)
+    IO.puts "ok|locahost:#{port}"
+    loop_acceptor(socket, env)
+  end
+
+  defp loop_acceptor(socket, env) do
+    {:ok, client} = :gen_tcp.accept(socket)
+    {:ok, pid} = Task.Supervisor.start_child(Alchemist.Server.Socket.TaskSupervisor, fn -> serve(client, env) end)
+    :ok = :gen_tcp.controlling_process(client, pid)
+    loop_acceptor(socket, env)
+  end
+
+  defp serve(socket, env) do
+    {:ok, io_string} = StringIO.open("")
+    socket
+    |> read_line
+    |> String.strip
+    |> ProcessCommands.process(env, io_string)
+
+    {:ok, {_, output}} = StringIO.close(io_string)
+    write_line(output, socket)
+
+    serve(socket, env)
+  end
+
+  defp read_line(socket) do
+    #TODO: handle {:error, :closed}
+    {:ok, data} = :gen_tcp.recv(socket, 0)
+    data
+  end
+
+  defp write_line(line, socket) do
+    :gen_tcp.send(socket, line)
+  end
+end

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -1,7 +1,6 @@
 Code.require_file "../helpers/process_commands.exs", __DIR__
 
 defmodule Alchemist.Server.Socket do
-  use Application
 
   alias Alchemist.Helpers.ProcessCommands
 

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -15,7 +15,7 @@ defmodule Alchemist.Server.Socket do
       worker(Task, [__MODULE__, :accept, [env, port]])
     ]
 
-    opts = [strategy: :one_for_one, name: KVServer.Supervisor]
+    opts = [strategy: :one_for_one, name: Alchemist.Server.Socket.Supervisor]
     Supervisor.start_link(children, opts)
   end
 

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.Server.Socket do
 
   alias Alchemist.Helpers.ProcessCommands
 
-  def start(_type, opts) do
+  def start(opts) do
     import Supervisor.Spec
 
     env = Keyword.get(opts, :env)

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -42,10 +42,8 @@ defmodule Alchemist.Server.Socket do
 
         data
         |> String.strip
-        |> ProcessCommands.process(env, io_string)
-
-        {:ok, {_, output}} = StringIO.close(io_string)
-        write_line(output, socket)
+        |> ProcessCommands.process(env)
+        |> write_line(socket)
 
         serve(socket, env)
     end

--- a/test/api/comp_test.exs
+++ b/test/api/comp_test.exs
@@ -4,14 +4,11 @@ Code.require_file "../../lib/api/comp.exs", __DIR__
 defmodule Alchemist.API.CompTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Comp
 
   test "COMP request with empty hint" do
-    assert capture_io(fn ->
-      Comp.process([nil, Elixir, [], [] ], Process.group_leader)
-    end) =~ """
+    assert Comp.process([nil, Elixir, [], [] ]) =~ """
     import/2
     quote/2
     require/2
@@ -20,9 +17,7 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request without empty hint" do
-    assert capture_io(fn ->
-      Comp.process(['is_b', Elixir, [], []], Process.group_leader)
-    end) =~ """
+    assert Comp.process(['is_b', Elixir, [], []]) =~ """
     is_b
     is_binary/1
     is_bitstring/1
@@ -32,9 +27,7 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request with an alias" do
-    assert capture_io(fn ->
-      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]], Process.group_leader)
-    end) =~ """
+    assert Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]]) =~ """
     MyList.flatten
     flatten/1
     flatten/2
@@ -43,15 +36,17 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request with a module hint" do
-    assert capture_io(fn ->
-      Comp.process(['Str', Elixir, [], []], Process.group_leader)
-    end) =~ """
+    assert Comp.process(['Str', Elixir, [], []]) =~ """
     Str
     Stream
     String
     StringIO
     END-OF-COMP
     """
+  end
+
+  test "COMP request with no match" do
+    assert Comp.process(['Fooo', Elixir, [], []]) == "END-OF-COMP\n"
   end
 
 end

--- a/test/api/comp_test.exs
+++ b/test/api/comp_test.exs
@@ -1,6 +1,5 @@
 Code.require_file "../test_helper.exs", __DIR__
 Code.require_file "../../lib/api/comp.exs", __DIR__
-Code.require_file "../../lib/server/io.exs", __DIR__
 
 defmodule Alchemist.API.CompTest do
 
@@ -8,11 +7,10 @@ defmodule Alchemist.API.CompTest do
   import ExUnit.CaptureIO
 
   alias Alchemist.API.Comp
-  alias Alchemist.Server.IO, as: ServerIO
 
   test "COMP request with empty hint" do
     assert capture_io(fn ->
-      Comp.process([nil, Elixir, [], [] ], ServerIO)
+      Comp.process([nil, Elixir, [], [] ], Process.group_leader)
     end) =~ """
     import/2
     quote/2
@@ -23,7 +21,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request without empty hint" do
     assert capture_io(fn ->
-      Comp.process(['is_b', Elixir, [], []], ServerIO)
+      Comp.process(['is_b', Elixir, [], []], Process.group_leader)
     end) =~ """
     is_b
     is_binary/1
@@ -35,7 +33,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request with an alias" do
     assert capture_io(fn ->
-      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]], ServerIO)
+      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]], Process.group_leader)
     end) =~ """
     MyList.flatten
     flatten/1
@@ -46,7 +44,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request with a module hint" do
     assert capture_io(fn ->
-      Comp.process(['Str', Elixir, [], []], ServerIO)
+      Comp.process(['Str', Elixir, [], []], Process.group_leader)
     end) =~ """
     Str
     Stream

--- a/test/api/comp_test.exs
+++ b/test/api/comp_test.exs
@@ -1,5 +1,6 @@
 Code.require_file "../test_helper.exs", __DIR__
 Code.require_file "../../lib/api/comp.exs", __DIR__
+Code.require_file "../../lib/server/io.exs", __DIR__
 
 defmodule Alchemist.API.CompTest do
 
@@ -7,10 +8,11 @@ defmodule Alchemist.API.CompTest do
   import ExUnit.CaptureIO
 
   alias Alchemist.API.Comp
+  alias Alchemist.Server.IO, as: ServerIO
 
   test "COMP request with empty hint" do
     assert capture_io(fn ->
-      Comp.process([nil, Elixir, [], [] ])
+      Comp.process([nil, Elixir, [], [] ], ServerIO)
     end) =~ """
     import/2
     quote/2
@@ -21,7 +23,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request without empty hint" do
     assert capture_io(fn ->
-      Comp.process(['is_b', Elixir, [], []])
+      Comp.process(['is_b', Elixir, [], []], ServerIO)
     end) =~ """
     is_b
     is_binary/1
@@ -33,7 +35,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request with an alias" do
     assert capture_io(fn ->
-      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]])
+      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]], ServerIO)
     end) =~ """
     MyList.flatten
     flatten/1
@@ -44,7 +46,7 @@ defmodule Alchemist.API.CompTest do
 
   test "COMP request with a module hint" do
     assert capture_io(fn ->
-      Comp.process(['Str', Elixir, [], []])
+      Comp.process(['Str', Elixir, [], []], ServerIO)
     end) =~ """
     Str
     Stream

--- a/test/api/docl_test.exs
+++ b/test/api/docl_test.exs
@@ -5,32 +5,30 @@ Code.require_file "../../lib/api/docl.exs", __DIR__
 defmodule Alchemist.API.DoclTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Docl
 
   test "DOCL full request" do
-    docl_resp = capture_io(fn ->
-      Docl.request(~s({ "defmodule", [ context: Elixir, imports: [], aliases: [] ] }), Process.group_leader)
-    end)
-   assert docl_resp =~ """
-   Defines a module given by name with the given contents.
-   """
-   assert docl_resp =~ ~r"END-OF-DOCL$"
+    docl_resp = Docl.request(~s({ "defmodule", [ context: Elixir, imports: [], aliases: [] ] }))
+    assert docl_resp =~ """
+    Defines a module given by name with the given contents.
+    """
+    assert docl_resp =~ ~r"END-OF-DOCL$"
   end
 
   test "DOCL request" do
-    assert capture_io(fn ->
-      Docl.process(['defmodule', [], []], Process.group_leader)
-    end) =~ """
+    assert Docl.process(['defmodule', [], []]) =~ """
     Defines a module given by name with the given contents.
     """
   end
 
+  test "DOCL request with no match" do
+    assert Docl.process(['FooBar', [], []]) =~ "Could not load module FooBar"
+  end
+
+
   test "DOCL request for List.flatten" do
-    assert capture_io(fn ->
-      Docl.process(["List.flatten", [], []], Process.group_leader)
-    end) =~ """
+    assert Docl.process(["List.flatten", [], []]) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
     \e[33mExamples\e[0m
@@ -40,9 +38,7 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for MyCustomList.flatten with alias" do
-    assert capture_io(fn ->
-      Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]], Process.group_leader)
-    end) =~ """
+    assert Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]]) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
     \e[33mExamples\e[0m
@@ -52,9 +48,7 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for search create_file with import" do
-    assert capture_io(fn ->
-      Docl.process(["create_file", [Mix.Generator], []], Process.group_leader)
-    end) =~ """
+    assert Docl.process(["create_file", [Mix.Generator], []]) =~ """
     def create_file(path, contents, opts \\\\ [])                   \e[0m
     \e[0m
     Creates a file with the given contents. If the file already exists, asks for
@@ -64,17 +58,13 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for defmacro" do
-    assert capture_io(fn ->
-      Docl.process(["defmacro", [], []], Process.group_leader)
-    end) =~ """
+    assert Docl.process(["defmacro", [], []]) =~ """
     \e[7m\e[33m                      defmacro defmacro(call, expr \\\\ nil)                      \e[0m
     """
   end
 
   test "DOCL request for Path.basename/1" do
-    assert capture_io(fn ->
-      Docl.process(["Path.basename/1", [], []], Process.group_leader)
-    end) =~ """
+    assert Docl.process(["Path.basename/1", [], []]) =~ """
     Returns the last component of the path or the path itself if it does not
     contain any directory separators.
     """

--- a/test/api/docl_test.exs
+++ b/test/api/docl_test.exs
@@ -11,7 +11,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request" do
     assert capture_io(fn ->
-      Docl.process(['defmodule', [], []])
+      Docl.process(['defmodule', [], []], Process.group_leader)
     end) =~ """
     Defines a module given by name with the given contents.
     """
@@ -19,7 +19,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request for List.flatten" do
     assert capture_io(fn ->
-      Docl.process(["List.flatten", [], []])
+      Docl.process(["List.flatten", [], []], Process.group_leader)
     end) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
@@ -31,7 +31,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request for MyCustomList.flatten with alias" do
     assert capture_io(fn ->
-      Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]])
+      Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]], Process.group_leader)
     end) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
@@ -43,7 +43,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request for search create_file with import" do
     assert capture_io(fn ->
-      Docl.process(["create_file", [Mix.Generator], []])
+      Docl.process(["create_file", [Mix.Generator], []], Process.group_leader)
     end) =~ """
     def create_file(path, contents, opts \\\\ [])                   \e[0m
     \e[0m
@@ -55,7 +55,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request for defmacro" do
     assert capture_io(fn ->
-      Docl.process(["defmacro", [], []])
+      Docl.process(["defmacro", [], []], Process.group_leader)
     end) =~ """
     \e[7m\e[33m                      defmacro defmacro(call, expr \\\\ nil)                      \e[0m
     """
@@ -63,7 +63,7 @@ defmodule Alchemist.API.DoclTest do
 
   test "DOCL request for Path.basename/1" do
     assert capture_io(fn ->
-      Docl.process(["Path.basename/1", [], []])
+      Docl.process(["Path.basename/1", [], []], Process.group_leader)
     end) =~ """
     Returns the last component of the path or the path itself if it does not
     contain any directory separators.

--- a/test/api/docl_test.exs
+++ b/test/api/docl_test.exs
@@ -9,6 +9,16 @@ defmodule Alchemist.API.DoclTest do
 
   alias Alchemist.API.Docl
 
+  test "DOCL full request" do
+    docl_resp = capture_io(fn ->
+      Docl.request(~s({ "defmodule", [ context: Elixir, imports: [], aliases: [] ] }), Process.group_leader)
+    end)
+   assert docl_resp =~ """
+   Defines a module given by name with the given contents.
+   """
+   assert docl_resp =~ ~r"END-OF-DOCL$"
+  end
+
   test "DOCL request" do
     assert capture_io(fn ->
       Docl.process(['defmodule', [], []], Process.group_leader)

--- a/test/api/ping_test.exs
+++ b/test/api/ping_test.exs
@@ -4,14 +4,11 @@ Code.require_file "../../lib/api/ping.exs", __DIR__
 defmodule Alchemist.API.PingTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Ping
 
   test "PING request" do
-    assert capture_io(fn ->
-      Ping.process(Process.group_leader)
-    end) =~ """
+    assert Ping.request =~ """
     PONG
     END-OF-PING
     """

--- a/test/api/ping_test.exs
+++ b/test/api/ping_test.exs
@@ -1,6 +1,5 @@
 Code.require_file "../test_helper.exs", __DIR__
 Code.require_file "../../lib/api/ping.exs", __DIR__
-Code.require_file "../../lib/server/io.exs", __DIR__
 
 defmodule Alchemist.API.PingTest do
 
@@ -8,11 +7,10 @@ defmodule Alchemist.API.PingTest do
   import ExUnit.CaptureIO
 
   alias Alchemist.API.Ping
-  alias Alchemist.Server.IO, as: ServerIO
 
   test "PING request" do
     assert capture_io(fn ->
-      Ping.process(ServerIO)
+      Ping.process(Process.group_leader)
     end) =~ """
     PONG
     END-OF-PING

--- a/test/api/ping_test.exs
+++ b/test/api/ping_test.exs
@@ -1,5 +1,6 @@
 Code.require_file "../test_helper.exs", __DIR__
 Code.require_file "../../lib/api/ping.exs", __DIR__
+Code.require_file "../../lib/server/io.exs", __DIR__
 
 defmodule Alchemist.API.PingTest do
 
@@ -7,10 +8,11 @@ defmodule Alchemist.API.PingTest do
   import ExUnit.CaptureIO
 
   alias Alchemist.API.Ping
+  alias Alchemist.Server.IO, as: ServerIO
 
   test "PING request" do
     assert capture_io(fn ->
-      Ping.process()
+      Ping.process(ServerIO)
     end) =~ """
     PONG
     END-OF-PING

--- a/test/helpers/process_commands_test.exs
+++ b/test/helpers/process_commands_test.exs
@@ -120,7 +120,7 @@ defmodule ServerTest do
 
   defp send_signal(signal) do
     capture_io(fn ->
-      Alchemist.Helpers.ProcessCommands.process(signal, "env", Process.group_leader)
+      Alchemist.Helpers.ProcessCommands.process(signal, "env") |> IO.write
     end)
   end
 end

--- a/test/helpers/process_commands_test.exs
+++ b/test/helpers/process_commands_test.exs
@@ -1,5 +1,5 @@
-Code.require_file "test_helper.exs", __DIR__
-Code.require_file "../lib/server.exs", __DIR__
+Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "../../lib/helpers/process_commands.exs", __DIR__
 
 defmodule ServerTest do
   use ExUnit.Case
@@ -7,10 +7,10 @@ defmodule ServerTest do
 
   setup_all do
     on_exit fn ->
-      {_status, files} = File.ls Path.expand("fixtures", __DIR__)
+      {_status, files} = File.ls Path.expand("../fixtures", __DIR__)
       files |> Enum.each(fn(file) ->
         unless file == ".gitkeep" do
-          File.rm Path.expand("fixtures/#{file}", __DIR__)
+          File.rm Path.expand("../fixtures/#{file}", __DIR__)
         end
       end)
     end
@@ -33,13 +33,13 @@ defmodule ServerTest do
   end
 
   test "Evaluate the content of a file" do
-    filename = Path.expand("fixtures/eval_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/eval_fixture.exs", __DIR__)
     File.write(filename, "1+1")
     assert send_signal("EVAL { :eval, '#{filename}' }") =~ "2"
   end
 
   test "Evaluate and quote the content of a file" do
-    filename = Path.expand("fixtures/eval_and_quote_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/eval_and_quote_fixture.exs", __DIR__)
     File.write(filename, "[4,2,1,3] |> Enum.sort")
     assert send_signal("EVAL { :quote, '#{filename}' }") =~ """
     {{:., [line: 1], [{:__aliases__, [counter: 0, line: 1], [:Enum]}, :sort]},\n   [line: 1], []}]}
@@ -47,7 +47,7 @@ defmodule ServerTest do
   end
 
   test "Expand macro once" do
-    filename = Path.expand("fixtures/macro_expand_once_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/macro_expand_once_fixture.exs", __DIR__)
     File.write(filename, "unless true, do: IO.puts \"this should never be printed\"")
     assert send_signal("EVAL { :expand_once, '#{filename}' }") =~ """
     if(true) do
@@ -59,7 +59,7 @@ defmodule ServerTest do
   end
 
   test "Expand macro" do
-    filename = Path.expand("fixtures/macro_expand_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/macro_expand_fixture.exs", __DIR__)
     File.write(filename, "unless true, do: IO.puts \"this should never be printed\"")
     assert send_signal("EVAL { :expand, '#{filename}' }") =~ """
     case(true) do
@@ -120,7 +120,7 @@ defmodule ServerTest do
 
   defp send_signal(signal) do
     capture_io(fn ->
-      Alchemist.Server.read_input(signal, Process.group_leader)
+      Alchemist.Helpers.ProcessCommands.process(signal, "env", Process.group_leader)
     end)
   end
 end

--- a/test/server/socket_test.exs
+++ b/test/server/socket_test.exs
@@ -7,7 +7,7 @@ defmodule Alchemist.Server.SocketTest do
   alias Alchemist.Server.Socket, as: ServerSocket
 
   setup do
-    ServerSocket.start(nil, [env: "dev", port: 55293])
+    ServerSocket.start([env: "dev", port: 55293])
     :ok
   end
 

--- a/test/server/socket_test.exs
+++ b/test/server/socket_test.exs
@@ -1,0 +1,32 @@
+Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "../../lib/server/socket.exs", __DIR__
+
+defmodule Alchemist.Server.SocketTest do
+  use ExUnit.Case
+
+  alias Alchemist.Server.Socket, as: ServerSocket
+
+  setup do
+    ServerSocket.start(nil, [env: "dev", port: 55293])
+    :ok
+  end
+
+  setup do
+    opts = [:binary, packet: :line, active: false]
+    {:ok, socket} = :gen_tcp.connect('localhost', 55293, opts)
+    {:ok, socket: socket}
+  end
+
+  test "server reply ping", %{socket: socket} do
+    assert send_and_recv(socket, "PING\n", 2) == "PONG\nEND-OF-PING\n"
+  end
+
+  defp send_and_recv(socket, command, num_lines) do
+    :ok = :gen_tcp.send(socket, command)
+    result = for _ <- 1..num_lines do
+      {:ok, data} = :gen_tcp.recv(socket, 0, 1000)
+      data
+    end
+    Enum.join(result)
+  end
+end

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -1,11 +1,9 @@
 Code.require_file "test_helper.exs", __DIR__
 Code.require_file "../lib/server.exs", __DIR__
-Code.require_file "../lib/server/io.exs", __DIR__
 
 defmodule ServerTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
-  alias Alchemist.Server.IO, as: ServerIO
 
   setup_all do
     on_exit fn ->
@@ -122,7 +120,7 @@ defmodule ServerTest do
 
   defp send_signal(signal) do
     capture_io(fn ->
-      Alchemist.Server.read_input(signal, ServerIO)
+      Alchemist.Server.read_input(signal, Process.group_leader)
     end)
   end
 end

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -1,9 +1,11 @@
 Code.require_file "test_helper.exs", __DIR__
 Code.require_file "../lib/server.exs", __DIR__
+Code.require_file "../lib/server/io.exs", __DIR__
 
 defmodule ServerTest do
   use ExUnit.Case
   import ExUnit.CaptureIO
+  alias Alchemist.Server.IO, as: ServerIO
 
   setup_all do
     on_exit fn ->
@@ -120,7 +122,7 @@ defmodule ServerTest do
 
   defp send_signal(signal) do
     capture_io(fn ->
-      Alchemist.Server.read_input(signal)
+      Alchemist.Server.read_input(signal, ServerIO)
     end)
   end
 end


### PR DESCRIPTION
By this change Alchemist.Server can listen to a port and reply the command through socket connection:

Starting the server
```
$ cd elixir_project
$ elixir path/to/alchemist-server/run.exs --env=dev --listen
ok|localhost:55580
```
Then the client connects and talk to the server like this:

```
$ nc localhost 56640
PING
PONG
END-OF-PING
COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
def
defexception/1
defoverridable/1
defstruct/1
def/2
defdelegate/2
defmacro/2
defmacrop/2
defmodule/2
defp/2
defprotocol/2
defimpl/3
END-OF-COMP
```
This changes allows us to introduce vim integration, if your interested to see how it would work, take look at [alchemist.vim](https://github.com/slashmili/alchemist.vim)