### PR TITLE
Implement communication with server via socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,17 @@ STAT_COLOR=\033[2;33m
 
 all: test
 
-test:	test_server
+test:
+	${MAKE} test_servers
 	${MAKE} test_helpers
 	${MAKE} test_api
 
-test_server:
+test_servers:
 	@ echo "\n$(INFO_COLOR)Run server tests: $(NO_COLOR)\n"
-	$(ELIXIR) test/server_test.exs
-
+	$(ELIXIR) test/server/socket_test.exs
 test_helpers:
 	@ echo "\n$(INFO_COLOR)Run helper tests: $(NO_COLOR)\n"
+	$(ELIXIR) test/helpers/process_commands_test.exs
 	$(ELIXIR) test/helpers/module_info_test.exs
 	$(ELIXIR) test/helpers/complete_test.exs
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Elixir Mix project and serves with informations as the following:
 
 # Usage
 
-The server needs to be started inside an Elixir mix project like below:
+The server needs to be started inside an Elixir mix project, it can be started in two ways:
 
+## Read/Write through `STDIN/STDOUT`
 ```
 $ cd elixir_project
-$ elixir path/to/alchemist-server/run.exs dev
+$ elixir path/to/alchemist-server/run.exs --env=dev
 ```
-
-The Alchemist-Server API is `STDIN/STDOUT` based, when input sent to a
-running server process it responds by sending information back to the `STDOUT`.
+In this mode, when input sent to a running server process it
+responds by sending information back to the `STDOUT`.
 
 A request consisting of two parts, the request type and the request arguments.
 
@@ -34,6 +34,22 @@ Example for a completion request:
 ```
 [type]   [arguments]
 
+COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
+```
+
+## Read/Write through network socket
+```
+$ cd elixir_project
+$ elixir path/to/alchemist-server/run.exs --env=dev --listen
+ok|localhost:55580
+```
+In this mode, when a client connects to the port, it
+responds by sending information back to the opened connection
+
+Example for a completion request:
+
+```
+$ nc localhost 55580
 COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
 ```
 

--- a/lib/api/comp.exs
+++ b/lib/api/comp.exs
@@ -1,10 +1,12 @@
 Code.require_file "../helpers/complete.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Comp do
 
   @moduledoc false
 
   alias Alchemist.Helpers.Complete
+  alias Alchemist.Helpers.Response
 
   def request(args) do
     args
@@ -14,14 +16,14 @@ defmodule Alchemist.API.Comp do
 
   def process([nil, _, imports, _]) do
     Complete.run('', imports) ++ Complete.run('')
-    |> print
+    |> response
   end
 
   def process([hint, _context, imports, aliases]) do
     Application.put_env(:"alchemist.el", :aliases, aliases)
 
     Complete.run(hint, imports) ++ Complete.run(hint)
-    |> print
+    |> response
   end
 
   defp normalize(request) do
@@ -31,11 +33,11 @@ defmodule Alchemist.API.Comp do
     [hint, context, imports, aliases]
   end
 
-  defp print(result) do
+  defp response(result) do
     result
     |> Enum.uniq
-    |> Enum.map(&IO.puts/1)
-
-    IO.puts "END-OF-COMP"
+    |> Enum.join("\n")
+    |> Response.endmark("COMP")
   end
+
 end

--- a/lib/api/defl.exs
+++ b/lib/api/defl.exs
@@ -1,19 +1,28 @@
 Code.require_file "../helpers/module_info.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Defl do
 
   @moduledoc false
 
   alias Alchemist.Helpers.ModuleInfo
+  alias Alchemist.Helpers.Response
 
   def request(args) do
     args
     |> normalize
     |> process
-    |> IO.puts
-
-    IO.puts "END-OF-DEFL"
+    |> endmark("DEFL")
   end
+
+  defp endmark(nil , cmd) do
+    "\n" <> Response.endmark(nil, cmd)
+  end
+
+  defp endmark(response , cmd) do
+    Response.endmark(response, cmd)
+  end
+
 
   def process([nil, function, [context: _, imports: [], aliases: _]]) do
     look_for_kernel_functions(function)

--- a/lib/api/docl.exs
+++ b/lib/api/docl.exs
@@ -1,4 +1,6 @@
 Code.require_file "../helpers/module_info.exs", __DIR__
+Code.require_file "../helpers/capture_io.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Docl do
 
@@ -7,15 +9,14 @@ defmodule Alchemist.API.Docl do
   import IEx.Helpers, warn: false
 
   alias Alchemist.Helpers.ModuleInfo
+  alias Alchemist.Helpers.CaptureIO
+  alias Alchemist.Helpers.Response
 
   def request(args) do
-    Application.put_env(:iex, :colors, [enabled: true])
-
     args
     |> normalize
     |> process
-
-    IO.puts "END-OF-DOCL"
+    |> Response.endmark("DOCL")
   end
 
   def process([expr, modules, aliases]) do
@@ -25,7 +26,10 @@ defmodule Alchemist.API.Docl do
   def search(nil), do: true
   def search(expr) do
     try do
-      Code.eval_string("h(#{expr})", [], __ENV__)
+      help = CaptureIO.capture_io(fn ->
+        Code.eval_string("h(#{expr})", [], __ENV__)
+      end)
+      help
     rescue
       _e -> nil
     end

--- a/lib/api/eval.exs
+++ b/lib/api/eval.exs
@@ -1,59 +1,71 @@
+Code.require_file "../helpers/response.exs", __DIR__
+
 defmodule Alchemist.API.Eval do
 
   @moduledoc false
+
+  alias Alchemist.Helpers.CaptureIO
+  alias Alchemist.Helpers.Response
 
   def request(args) do
     args
     |> normalize
     |> process
-
-    IO.puts "END-OF-EVAL"
+    |> Response.endmark("EVAL")
   end
 
   def process({:eval, file}) do
-    try do
-      File.read!("#{file}")
-      |> Code.eval_string
-      |> Tuple.to_list
-      |> List.first
-      |> IO.inspect
-    rescue
-      e -> IO.inspect e
-    end
+    CaptureIO.capture_io(fn ->
+      try do
+        File.read!("#{file}")
+        |> Code.eval_string
+        |> Tuple.to_list
+        |> List.first
+        |> IO.inspect
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
   def process({:quote, file}) do
-    try do
-      File.read!("#{file}")
-      |> Code.string_to_quoted
-      |> Tuple.to_list
-      |> List.last
-      |> IO.inspect
-    rescue
-      e -> IO.inspect e
-    end
+    CaptureIO.capture_io(fn ->
+      try do
+        File.read!("#{file}")
+        |> Code.string_to_quoted
+        |> Tuple.to_list
+        |> List.last
+        |> IO.inspect
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
   def process({:expand, file}) do
-    try do
-      {_, expr} = File.read!("#{file}")
-      |> Code.string_to_quoted
-      res = Macro.expand(expr, __ENV__)
-      IO.puts Macro.to_string(res)
-    rescue
-      e -> IO.inspect e
-    end
+    CaptureIO.capture_io(fn ->
+      try do
+        {_, expr} = File.read!("#{file}")
+                    |> Code.string_to_quoted
+        res = Macro.expand(expr, __ENV__)
+        IO.puts Macro.to_string(res)
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
   def process({:expand_once, file}) do
-    try do
-      {_, expr} = File.read!("#{file}")
-      |> Code.string_to_quoted
-      res = Macro.expand_once(expr, __ENV__)
-      IO.puts Macro.to_string(res)
-    rescue
-      e -> IO.inspect e
-    end
+    CaptureIO.capture_io(fn ->
+      try do
+        {_, expr} = File.read!("#{file}")
+                    |> Code.string_to_quoted
+        res = Macro.expand_once(expr, __ENV__)
+        IO.puts Macro.to_string(res)
+      rescue
+        e -> IO.inspect e
+      end
+    end)
   end
 
   def normalize(request) do

--- a/lib/api/info.exs
+++ b/lib/api/info.exs
@@ -1,5 +1,7 @@
 Code.require_file "../helpers/module_info.exs", __DIR__
 Code.require_file "../helpers/complete.exs", __DIR__
+Code.require_file "../helpers/capture_io.exs", __DIR__
+Code.require_file "../helpers/response.exs", __DIR__
 
 defmodule Alchemist.API.Info do
 
@@ -9,11 +11,14 @@ defmodule Alchemist.API.Info do
 
   alias Alchemist.Helpers.ModuleInfo
   alias Alchemist.Helpers.Complete
+  alias Alchemist.Helpers.CaptureIO
+  alias Alchemist.Helpers.Response
 
   def request(args) do
     args
     |> normalize
     |> process
+    |> Response.endmark("INFO")
   end
 
   def process(:modules) do
@@ -26,9 +31,7 @@ defmodule Alchemist.API.Info do
 
     modules ++ functions
     |> Enum.uniq
-    |> Enum.map(&IO.puts/1)
-
-    IO.puts "END-OF-INFO"
+    |> Enum.join("\n")
   end
 
   def process(:mixtasks) do
@@ -39,33 +42,31 @@ defmodule Alchemist.API.Info do
     |> Mix.Task.load_tasks
     |> Enum.map(&Mix.Task.task_name/1)
     |> Enum.sort
-    |> Enum.map(&IO.puts/1)
-
-    IO.puts "END-OF-INFO"
+    |> Enum.join("\n")
   end
 
   def process({:info, arg}) do
     try do
-      Code.eval_string("i(#{arg})", [], __ENV__)
+      CaptureIO.capture_io(fn ->
+        Code.eval_string("i(#{arg})", [], __ENV__)
+      end)
     rescue
       _e -> nil
     end
-
-    IO.puts "END-OF-INFO"
   end
 
   def process({:types, arg}) do
     try do
-      Code.eval_string("t(#{arg})", [], __ENV__)
+      CaptureIO.capture_io(fn ->
+        Code.eval_string("t(#{arg})", [], __ENV__)
+      end)
     rescue
       _e -> nil
     end
-
-    IO.puts "END-OF-INFO"
   end
 
   def process(nil) do
-    IO.puts "END-OF-INFO"
+   nil
   end
 
   def normalize(request) do

--- a/lib/api/ping.exs
+++ b/lib/api/ping.exs
@@ -1,13 +1,12 @@
+Code.require_file "../helpers/response.exs", __DIR__
+
 defmodule Alchemist.API.Ping do
 
   @moduledoc false
 
-  def request do
-    process
-  end
+  alias Alchemist.Helpers.Response
 
-  def process do
-    IO.puts "PONG"
-    IO.puts "END-OF-PING"
+  def request do
+    Response.endmark("PONG", "PING")
   end
 end

--- a/lib/helpers/capture_io.exs
+++ b/lib/helpers/capture_io.exs
@@ -1,0 +1,38 @@
+defmodule Alchemist.Helpers.CaptureIO do
+
+  @docmodule false
+
+  def capture_io(fun) do
+    do_capture_io(:standard_io, [], fun)
+  end
+
+  defp do_capture_io(:standard_io, options, fun) do
+    prompt_config = Keyword.get(options, :capture_prompt, true)
+    input = Keyword.get(options, :input, "")
+
+    original_gl = Process.group_leader()
+    {:ok, capture_gl} = StringIO.open(input, capture_prompt: prompt_config)
+    try do
+      Process.group_leader(self(), capture_gl)
+      do_capture_io(capture_gl, fun)
+    after
+      Process.group_leader(self(), original_gl)
+    end
+  end
+
+  def do_capture_io(string_io, fun) do
+    try do
+       _ = fun.()
+      :ok
+    catch
+      kind, reason ->
+        stack = System.stacktrace()
+        _ = StringIO.close(string_io)
+        :erlang.raise(kind, reason, stack)
+    else
+      :ok ->
+        {:ok, output} = StringIO.close(string_io)
+        elem(output, 1)
+    end
+  end
+end

--- a/lib/helpers/process_commands.exs
+++ b/lib/helpers/process_commands.exs
@@ -1,0 +1,80 @@
+Code.require_file "../api/comp.exs", __DIR__
+Code.require_file "../api/docl.exs", __DIR__
+Code.require_file "../api/defl.exs", __DIR__
+Code.require_file "../api/eval.exs", __DIR__
+Code.require_file "../api/info.exs", __DIR__
+Code.require_file "../api/ping.exs", __DIR__
+
+defmodule Alchemist.Helpers.ProcessCommands do
+
+  @moduledoc false
+
+  alias Alchemist.API
+
+  def process(line, env) do
+    loaded = all_loaded
+
+    paths = load_paths(env)
+    apps  = load_apps(env)
+
+    result = execute_input(line)
+    purge_modules(loaded)
+    purge_paths(paths)
+    purge_apps(apps)
+    result
+  end
+
+  defp execute_input(line) do
+    case line |> String.split(" ", parts: 2) do
+      ["COMP", args] ->
+        API.Comp.request(args)
+      ["DOCL", args] ->
+        API.Docl.request(args)
+      ["INFO", args] ->
+        API.Info.request(args)
+      ["EVAL", args] ->
+        API.Eval.request(args)
+      ["DEFL", args] ->
+        API.Defl.request(args)
+      ["PING"] ->
+        API.Ping.request()
+      _ ->
+        nil
+    end
+  end
+
+  defp all_loaded() do
+    for {m,_} <- :code.all_loaded, do: m
+  end
+
+  defp load_paths(env) do
+    for path <- Path.wildcard("_build/#{env}/lib/*/ebin") do
+      Code.prepend_path(path)
+      path
+    end
+  end
+
+  defp load_apps(env) do
+    for path <- Path.wildcard("_build/#{env}/lib/*/ebin/*.app") do
+      app = path |> Path.basename() |> Path.rootname() |> String.to_atom
+      Application.load(app)
+      app
+    end
+  end
+
+  defp purge_modules(loaded) do
+    for m <- (all_loaded() -- loaded) do
+      :code.delete(m)
+      :code.purge(m)
+    end
+  end
+
+  defp purge_paths(paths) do
+    for p <- paths, do: Code.delete_path(p)
+  end
+
+  defp purge_apps(apps) do
+    for a <- apps, do: Application.unload(a)
+  end
+
+end

--- a/lib/helpers/response.exs
+++ b/lib/helpers/response.exs
@@ -1,0 +1,17 @@
+defmodule Alchemist.Helpers.Response do
+
+  @moduledoc false
+
+  def endmark(nil, cmd) do
+    "END-OF-#{cmd}\n"
+  end
+
+  def endmark("", cmd) do
+    "END-OF-#{cmd}\n"
+  end
+
+  def endmark(response, cmd) do
+    response = String.strip(response)
+    "#{response}\nEND-OF-#{cmd}\n"
+  end
+end

--- a/lib/server.exs
+++ b/lib/server.exs
@@ -1,9 +1,5 @@
-Code.require_file "api/comp.exs", __DIR__
-Code.require_file "api/docl.exs", __DIR__
-Code.require_file "api/defl.exs", __DIR__
-Code.require_file "api/eval.exs", __DIR__
-Code.require_file "api/info.exs", __DIR__
-Code.require_file "api/ping.exs", __DIR__
+Code.require_file "server/io.exs", __DIR__
+Code.require_file "server/socket.exs", __DIR__
 
 defmodule Alchemist.Server do
 
@@ -21,76 +17,18 @@ defmodule Alchemist.Server do
     * Listing of all available Modules with documentation.
   """
 
-  alias Alchemist.API
+  alias Alchemist.Server.IO, as: ServerIO
+  alias Alchemist.Server.Socket, as: ServerSocket
 
-  def start([env]) do
-    loop(all_loaded(), env)
-  end
-
-  def loop(loaded, env) do
-    line  = IO.gets("") |> String.rstrip()
-    paths = load_paths(env)
-    apps  = load_apps(env)
-
-    read_input(line)
-
-    purge_modules(loaded)
-    purge_paths(paths)
-    purge_apps(apps)
-
-    loop(loaded, env)
-  end
-
-  def read_input(line) do
-    case line |> String.split(" ", parts: 2) do
-      ["COMP", args] ->
-        API.Comp.request(args)
-      ["DOCL", args] ->
-        API.Docl.request(args)
-      ["INFO", args] ->
-        API.Info.request(args)
-      ["EVAL", args] ->
-        API.Eval.request(args)
-      ["DEFL", args] ->
-        API.Defl.request(args)
-      ["PING"] ->
-        API.Ping.request()
-      _ ->
-        nil
+  def start([args]) do
+    {opts, _, _} = OptionParser.parse(args)
+    env = Keyword.get(opts, :env, "dev")
+    noansi = Keyword.get(opts, :no_ansi, false)
+    Application.put_env(:iex, :colors, [enabled: !noansi])
+    case Keyword.get(opts, :listen, false) do
+      false -> ServerIO.start([env: env])
+      true -> ServerSocket.start([env: env])
     end
-  end
-
-  defp all_loaded() do
-    for {m,_} <- :code.all_loaded, do: m
-  end
-
-  defp load_paths(env) do
-    for path <- Path.wildcard("_build/#{env}/lib/*/ebin") do
-      Code.prepend_path(path)
-      path
-    end
-  end
-
-  defp load_apps(env) do
-    for path <- Path.wildcard("_build/#{env}/lib/*/ebin/*.app") do
-      app = path |> Path.basename() |> Path.rootname() |> String.to_atom
-      Application.load(app)
-      app
-    end
-  end
-
-  defp purge_modules(loaded) do
-    for m <- (all_loaded() -- loaded) do
-      :code.delete(m)
-      :code.purge(m)
-    end
-  end
-
-  defp purge_paths(paths) do
-    for p <- paths, do: Code.delete_path(p)
-  end
-
-  defp purge_apps(apps) do
-    for a <- apps, do: Application.unload(a)
+    :timer.sleep :infinity
   end
 end

--- a/lib/server/io.exs
+++ b/lib/server/io.exs
@@ -1,0 +1,29 @@
+Code.require_file "../helpers/process_commands.exs", __DIR__
+
+defmodule Alchemist.Server.IO do
+
+  @moduledoc false
+
+  use GenServer
+
+  alias Alchemist.Helpers.ProcessCommands
+
+  def start(opts) do
+    env = Keyword.get(opts, :env)
+    GenServer.start_link(__MODULE__,  env, [])
+  end
+
+  def init(env) do
+    {:ok, env, 0}
+  end
+
+  def handle_info(:timeout, env) do
+    ProcessCommands.process(read_line, env)
+    |> IO.write
+    {:noreply, env, 0}
+  end
+
+  def read_line do
+    IO.gets("") |> String.rstrip()
+  end
+end

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -1,0 +1,61 @@
+Code.require_file "../helpers/process_commands.exs", __DIR__
+
+defmodule Alchemist.Server.Socket do
+
+  alias Alchemist.Helpers.ProcessCommands
+
+  def start(opts) do
+    import Supervisor.Spec
+
+    env = Keyword.get(opts, :env)
+    port = Keyword.get(opts, :port, 0)
+
+    children = [
+      supervisor(Task.Supervisor, [[name: Alchemist.Server.Socket.TaskSupervisor]]),
+      worker(Task, [__MODULE__, :accept, [env, port]])
+    ]
+
+    opts = [strategy: :one_for_one, name: Alchemist.Server.Socket.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def accept(env, port) do
+    {:ok, socket} = :gen_tcp.listen(port,
+                    [:binary, packet: :line, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(socket)
+    IO.puts "ok|localhost:#{port}"
+    loop_acceptor(socket, env)
+  end
+
+  defp loop_acceptor(socket, env) do
+    {:ok, client} = :gen_tcp.accept(socket)
+    {:ok, pid} = Task.Supervisor.start_child(Alchemist.Server.Socket.TaskSupervisor, fn -> serve(client, env) end)
+    :ok = :gen_tcp.controlling_process(client, pid)
+    loop_acceptor(socket, env)
+  end
+
+  defp serve(socket, env) do
+    case read_line(socket) do
+      :closed -> {:stop, :closed}
+      data when is_binary(data) ->
+
+        data
+        |> String.strip
+        |> ProcessCommands.process(env)
+        |> write_line(socket)
+
+        serve(socket, env)
+    end
+  end
+
+  defp read_line(socket) do
+    case :gen_tcp.recv(socket, 0) do
+      {:ok, data} -> data
+      {:error, :closed} -> :closed
+    end
+  end
+
+  defp write_line(line, socket) do
+    :gen_tcp.send(socket, line)
+  end
+end

--- a/test/api/comp_test.exs
+++ b/test/api/comp_test.exs
@@ -4,14 +4,11 @@ Code.require_file "../../lib/api/comp.exs", __DIR__
 defmodule Alchemist.API.CompTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Comp
 
   test "COMP request with empty hint" do
-    assert capture_io(fn ->
-      Comp.process([nil, Elixir, [], [] ])
-    end) =~ """
+    assert Comp.process([nil, Elixir, [], [] ]) =~ """
     import/2
     quote/2
     require/2
@@ -20,9 +17,7 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request without empty hint" do
-    assert capture_io(fn ->
-      Comp.process(['is_b', Elixir, [], []])
-    end) =~ """
+    assert Comp.process(['is_b', Elixir, [], []]) =~ """
     is_b
     is_binary/1
     is_bitstring/1
@@ -32,9 +27,7 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request with an alias" do
-    assert capture_io(fn ->
-      Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]])
-    end) =~ """
+    assert Comp.process(['MyList.flat', Elixir, [], [{MyList, List}]]) =~ """
     MyList.flatten
     flatten/1
     flatten/2
@@ -43,15 +36,17 @@ defmodule Alchemist.API.CompTest do
   end
 
   test "COMP request with a module hint" do
-    assert capture_io(fn ->
-      Comp.process(['Str', Elixir, [], []])
-    end) =~ """
+    assert Comp.process(['Str', Elixir, [], []]) =~ """
     Str
     Stream
     String
     StringIO
     END-OF-COMP
     """
+  end
+
+  test "COMP request with no match" do
+    assert Comp.process(['Fooo', Elixir, [], []]) == "END-OF-COMP\n"
   end
 
 end

--- a/test/api/docl_test.exs
+++ b/test/api/docl_test.exs
@@ -5,22 +5,30 @@ Code.require_file "../../lib/api/docl.exs", __DIR__
 defmodule Alchemist.API.DoclTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Docl
 
+  test "DOCL full request" do
+    docl_resp = Docl.request(~s({ "defmodule", [ context: Elixir, imports: [], aliases: [] ] }))
+    assert docl_resp =~ """
+    Defines a module given by name with the given contents.
+    """
+    assert docl_resp =~ ~r"END-OF-DOCL$"
+  end
+
   test "DOCL request" do
-    assert capture_io(fn ->
-      Docl.process(['defmodule', [], []])
-    end) =~ """
+    assert Docl.process(['defmodule', [], []]) =~ """
     Defines a module given by name with the given contents.
     """
   end
 
+  test "DOCL request with no match" do
+    assert Docl.process(['FooBar', [], []]) =~ "Could not load module FooBar"
+  end
+
+
   test "DOCL request for List.flatten" do
-    assert capture_io(fn ->
-      Docl.process(["List.flatten", [], []])
-    end) =~ """
+    assert Docl.process(["List.flatten", [], []]) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
     \e[33mExamples\e[0m
@@ -30,9 +38,7 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for MyCustomList.flatten with alias" do
-    assert capture_io(fn ->
-      Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]])
-    end) =~ """
+    assert Docl.process(["MyCustomList.flatten", [], [{MyCustomList, List}]]) =~ """
     Flattens the given \e[36mlist\e[0m of nested lists.
     \e[0m
     \e[33mExamples\e[0m
@@ -42,9 +48,7 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for search create_file with import" do
-    assert capture_io(fn ->
-      Docl.process(["create_file", [Mix.Generator], []])
-    end) =~ """
+    assert Docl.process(["create_file", [Mix.Generator], []]) =~ """
     def create_file(path, contents, opts \\\\ [])                   \e[0m
     \e[0m
     Creates a file with the given contents. If the file already exists, asks for
@@ -54,17 +58,13 @@ defmodule Alchemist.API.DoclTest do
   end
 
   test "DOCL request for defmacro" do
-    assert capture_io(fn ->
-      Docl.process(["defmacro", [], []])
-    end) =~ """
+    assert Docl.process(["defmacro", [], []]) =~ """
     \e[7m\e[33m                      defmacro defmacro(call, expr \\\\ nil)                      \e[0m
     """
   end
 
   test "DOCL request for Path.basename/1" do
-    assert capture_io(fn ->
-      Docl.process(["Path.basename/1", [], []])
-    end) =~ """
+    assert Docl.process(["Path.basename/1", [], []]) =~ """
     Returns the last component of the path or the path itself if it does not
     contain any directory separators.
     """

--- a/test/api/ping_test.exs
+++ b/test/api/ping_test.exs
@@ -4,14 +4,11 @@ Code.require_file "../../lib/api/ping.exs", __DIR__
 defmodule Alchemist.API.PingTest do
 
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   alias Alchemist.API.Ping
 
   test "PING request" do
-    assert capture_io(fn ->
-      Ping.process()
-    end) =~ """
+    assert Ping.request =~ """
     PONG
     END-OF-PING
     """

--- a/test/helpers/process_commands_test.exs
+++ b/test/helpers/process_commands_test.exs
@@ -1,5 +1,5 @@
-Code.require_file "test_helper.exs", __DIR__
-Code.require_file "../lib/server.exs", __DIR__
+Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "../../lib/helpers/process_commands.exs", __DIR__
 
 defmodule ServerTest do
   use ExUnit.Case
@@ -7,10 +7,10 @@ defmodule ServerTest do
 
   setup_all do
     on_exit fn ->
-      {_status, files} = File.ls Path.expand("fixtures", __DIR__)
+      {_status, files} = File.ls Path.expand("../fixtures", __DIR__)
       files |> Enum.each(fn(file) ->
         unless file == ".gitkeep" do
-          File.rm Path.expand("fixtures/#{file}", __DIR__)
+          File.rm Path.expand("../fixtures/#{file}", __DIR__)
         end
       end)
     end
@@ -33,13 +33,13 @@ defmodule ServerTest do
   end
 
   test "Evaluate the content of a file" do
-    filename = Path.expand("fixtures/eval_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/eval_fixture.exs", __DIR__)
     File.write(filename, "1+1")
     assert send_signal("EVAL { :eval, '#{filename}' }") =~ "2"
   end
 
   test "Evaluate and quote the content of a file" do
-    filename = Path.expand("fixtures/eval_and_quote_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/eval_and_quote_fixture.exs", __DIR__)
     File.write(filename, "[4,2,1,3] |> Enum.sort")
     assert send_signal("EVAL { :quote, '#{filename}' }") =~ """
     {{:., [line: 1], [{:__aliases__, [counter: 0, line: 1], [:Enum]}, :sort]},\n   [line: 1], []}]}
@@ -47,7 +47,7 @@ defmodule ServerTest do
   end
 
   test "Expand macro once" do
-    filename = Path.expand("fixtures/macro_expand_once_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/macro_expand_once_fixture.exs", __DIR__)
     File.write(filename, "unless true, do: IO.puts \"this should never be printed\"")
     assert send_signal("EVAL { :expand_once, '#{filename}' }") =~ """
     if(true) do
@@ -59,7 +59,7 @@ defmodule ServerTest do
   end
 
   test "Expand macro" do
-    filename = Path.expand("fixtures/macro_expand_fixture.exs", __DIR__)
+    filename = Path.expand("../fixtures/macro_expand_fixture.exs", __DIR__)
     File.write(filename, "unless true, do: IO.puts \"this should never be printed\"")
     assert send_signal("EVAL { :expand, '#{filename}' }") =~ """
     case(true) do
@@ -120,7 +120,7 @@ defmodule ServerTest do
 
   defp send_signal(signal) do
     capture_io(fn ->
-      Alchemist.Server.read_input(signal)
+      Alchemist.Helpers.ProcessCommands.process(signal, "env") |> IO.write
     end)
   end
 end

--- a/test/server/socket_test.exs
+++ b/test/server/socket_test.exs
@@ -1,0 +1,32 @@
+Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "../../lib/server/socket.exs", __DIR__
+
+defmodule Alchemist.Server.SocketTest do
+  use ExUnit.Case
+
+  alias Alchemist.Server.Socket, as: ServerSocket
+
+  setup do
+    ServerSocket.start([env: "dev", port: 55293])
+    :ok
+  end
+
+  setup do
+    opts = [:binary, packet: :line, active: false]
+    {:ok, socket} = :gen_tcp.connect('localhost', 55293, opts)
+    {:ok, socket: socket}
+  end
+
+  test "server reply ping", %{socket: socket} do
+    assert send_and_recv(socket, "PING\n", 2) == "PONG\nEND-OF-PING\n"
+  end
+
+  defp send_and_recv(socket, command, num_lines) do
+    :ok = :gen_tcp.send(socket, command)
+    result = for _ <- 1..num_lines do
+      {:ok, data} = :gen_tcp.recv(socket, 0, 1000)
+      data
+    end
+    Enum.join(result)
+  end
+end


### PR DESCRIPTION
Implement Server.IO and Server.Socket which each handles writing to
clients separately and move the logic of executing the commands to
Helpers.ProcessCommands. Refactor the commands to return the response as
string.

Also introduce options:
    --listen  runs Alchemist Server and listens to a random port
    --no-ansi disable :iex colors
    --env     set the environment which loads the build file from

Starting the server
```
$ cd elixir_project
$ elixir path/to/alchemist-server/run.exs --env=dev --listen
ok|localhost:55580
```
Then the client connects and talk to the server like this:

```
$ nc localhost 55580
PING
PONG
END-OF-PING
COMP { "def", [ context: Elixir, imports: [Enum], aliases: [{MyList, List}] ] }
def
defexception/1
defoverridable/1
defstruct/1
def/2
defdelegate/2
defmacro/2
defmacrop/2
defmodule/2
defp/2
defprotocol/2
defimpl/3
END-OF-COMP
```