### PR TITLE
Parsing --port argument as integer

### DIFF
--- a/lib/server.exs
+++ b/lib/server.exs
@@ -21,13 +21,13 @@ defmodule Alchemist.Server do
   alias Alchemist.Server.Socket, as: ServerSocket
 
   def start([args]) do
-    {opts, _, _} = OptionParser.parse(args)
+    {opts, _, _} = OptionParser.parse(args, switches: [port: :integer])
     env = Keyword.get(opts, :env, "dev")
     noansi = Keyword.get(opts, :no_ansi, false)
     Application.put_env(:iex, :colors, [enabled: !noansi])
     case Keyword.get(opts, :listen, false) do
       false -> ServerIO.start([env: env])
-      true -> ServerSocket.start([env: env])
+      true -> ServerSocket.start(opts)
     end
     :timer.sleep :infinity
   end

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -8,7 +8,7 @@ defmodule Alchemist.Server.Socket do
     import Supervisor.Spec
 
     env = Keyword.get(opts, :env)
-    port = Keyword.get(opts, :port, 0)
+    port = Keyword.get(opts, :port, 53000)
 
     children = [
       supervisor(Task.Supervisor, [[name: Alchemist.Server.Socket.TaskSupervisor]]),

--- a/lib/server/socket.exs
+++ b/lib/server/socket.exs
@@ -8,7 +8,7 @@ defmodule Alchemist.Server.Socket do
     import Supervisor.Spec
 
     env = Keyword.get(opts, :env)
-    port = Keyword.get(opts, :port, 53000)
+    port = Keyword.get(opts, :port, 0)
 
     children = [
       supervisor(Task.Supervisor, [[name: Alchemist.Server.Socket.TaskSupervisor]]),


### PR DESCRIPTION
When started with socket listener on dedicated port, the server crashes due to the "port" command line argument being parsed as string.